### PR TITLE
Remove calls to <Collection>::with_capacity().

### DIFF
--- a/src/collection_impls.rs
+++ b/src/collection_impls.rs
@@ -149,7 +149,7 @@ impl<K, V> Decodable for HashMap<K, V>
 {
     fn decode<D: Decoder>(d: &mut D) -> Result<HashMap<K, V>, D::Error> {
         d.read_map(|d, len| {
-            let mut map = HashMap::with_capacity(len);
+            let mut map = HashMap::new();
             for i in 0..len {
                 let key = try!(d.read_map_elt_key(i, |d| Decodable::decode(d)));
                 let val = try!(d.read_map_elt_val(i, |d| Decodable::decode(d)));
@@ -176,7 +176,7 @@ impl<T> Encodable for HashSet<T> where T: Encodable + Hash + Eq {
 impl<T> Decodable for HashSet<T> where T: Decodable + Hash + Eq, {
     fn decode<D: Decoder>(d: &mut D) -> Result<HashSet<T>, D::Error> {
         d.read_seq(|d, len| {
-            let mut set = HashSet::with_capacity(len);
+            let mut set = HashSet::new();
             for i in 0..len {
                 set.insert(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
             }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -479,7 +479,7 @@ impl<T:Encodable> Encodable for Vec<T> {
 impl<T:Decodable> Decodable for Vec<T> {
     fn decode<D: Decoder>(d: &mut D) -> Result<Vec<T>, D::Error> {
         d.read_seq(|d, len| {
-            let mut v = Vec::with_capacity(len);
+            let mut v = Vec::new();
             for i in 0..len {
                 v.push(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
             }
@@ -722,7 +722,7 @@ impl<D: Decoder> DecoderHelpers for D {
         FnMut(&mut D) -> Result<T, D::Error>,
     {
         self.read_seq(|this, len| {
-            let mut v = Vec::with_capacity(len);
+            let mut v = Vec::new();
             for i in 0..len {
                 v.push(try!(this.read_seq_elt(i, |this| f(this))));
             }


### PR DESCRIPTION
For instances where the length of a collection
must be obeyed, but is untrusted, calls to
with_capacity() could result in OOM errors.

This change makes it so that collections don't
pre-allocate memory at all.
